### PR TITLE
Auto-reset support for NodeMCU devkit as well as esprog,etc.

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -128,12 +128,14 @@ class ESPROM:
     def connect(self):
         print 'Connecting...'
 
-        # RTS = CH_PD (i.e reset)
-        # DTR = GPIO0
+        # RTS = either CH_PD or nRESET (both active low = chip in reset)
+        # DTR = GPIO0 (active low = boot to flasher)
+        self._port.setDTR(False)
         self._port.setRTS(True)
+        time.sleep(0.05)
         self._port.setDTR(True)
         self._port.setRTS(False)
-        time.sleep(0.1)
+        time.sleep(0.05)
         self._port.setDTR(False)
 
         self._port.timeout = 0.5


### PR DESCRIPTION
The NodeMCU dev-kit board has a similar auto-reset circuit to previous
ones (RTS drives reset, DTR drives GPIO0), but with a quirk - if both
RTS & DTR are asserted at once, neither nRESET nor GPIO0 are asserted.

This commit changes the reset order so RTS,DTR are asserted one at a
time instead of simultaneously. This should still work with the
traditional configuration as well.

This problem was mentioned in #26.