### PR TITLE
More auto-reset improvements

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -150,6 +150,10 @@ class ESPROM:
                     return
                 except:
                     time.sleep(0.05)
+            # this is a workaround for the CH340 serial driver on current versions of Linux,
+            # which seems to sometimes set the serial port up with wrong parameters
+            self._port.close()
+            self._port.open()
         raise Exception('Failed to connect')
 
     """ Read memory address in target """

--- a/esptool.py
+++ b/esptool.py
@@ -128,26 +128,28 @@ class ESPROM:
     def connect(self):
         print 'Connecting...'
 
-        # RTS = either CH_PD or nRESET (both active low = chip in reset)
-        # DTR = GPIO0 (active low = boot to flasher)
-        self._port.setDTR(False)
-        self._port.setRTS(True)
-        time.sleep(0.05)
-        self._port.setDTR(True)
-        self._port.setRTS(False)
-        time.sleep(0.05)
-        self._port.setDTR(False)
+        for _ in xrange(4):
+            # issue reset-to-bootloader:
+            # RTS = either CH_PD or nRESET (both active low = chip in reset)
+            # DTR = GPIO0 (active low = boot to flasher)
+            self._port.setDTR(False)
+            self._port.setRTS(True)
+            time.sleep(0.05)
+            self._port.setDTR(True)
+            self._port.setRTS(False)
+            time.sleep(0.05)
+            self._port.setDTR(False)
 
-        self._port.timeout = 0.5
-        for i in xrange(10):
-            try:
-                self._port.flushInput()
-                self._port.flushOutput()
-                self.sync()
-                self._port.timeout = 5
-                return
-            except:
-                time.sleep(0.1)
+            self._port.timeout = 0.3 # worst-case latency timer should be 255ms (probably <20ms)
+            for _ in xrange(4):
+                try:
+                    self._port.flushInput()
+                    self._port.flushOutput()
+                    self.sync()
+                    self._port.timeout = 5
+                    return
+                except:
+                    time.sleep(0.05)
         raise Exception('Failed to connect')
 
     """ Read memory address in target """


### PR DESCRIPTION
These changes are mostly based on a discussion I had with @markusgritsch regarding 88baa738a5b7ee5 (PR #30). Lots of discussion in that commit thread.

The first commit here should improve the reliability of auto-resets (using either the "standard" or the NodeMCU reset scheme).

The second commit helps avoid something that is probably unique to Linux, where the CH340 doesn't always switch baud rates like it should - resulting in random slow uploads at times. This shouldn't have any side effects on other OSes.

Thanks for all your work on esptool. :)