### PR TITLE
Make elf2image command thread-safe

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -25,6 +25,7 @@ import time
 import argparse
 import os
 import subprocess
+import tempfile
 
 class ESPROM:
 
@@ -358,11 +359,13 @@ class ELFFile:
         tool_objcopy = "xtensa-lx106-elf-objcopy"
         if os.getenv('XTENSA_CORE')=='lx106':
             tool_objcopy = "xt-objcopy"
-        subprocess.check_call([tool_objcopy, "--only-section", section, "-Obinary", self.name, ".tmp.section"])
-        f = open(".tmp.section", "rb")
-        data = f.read()
-        f.close()
-        os.remove(".tmp.section")
+        tmpsection = tempfile.mktemp(suffix=".section")
+        try:
+            subprocess.check_call([tool_objcopy, "--only-section", section, "-Obinary", self.name, tmpsection])
+            with open(tmpsection, "rb") as f:
+                data = f.read()
+        finally:
+            os.remove(tmpsection)
         return data
 
 


### PR DESCRIPTION
Hi,

Just another minor tweak from me. I run into this when running parallel builds of an esp firmware (the two elf2image commands run simultaneously).

Cheers,

Angus

***

Allows two elf2image commands to be run in parallel (ie parallal
make process).