### PR TITLE
Change shebang line to python2

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # ESP8266 ROM Bootloader Utility
 # https://github.com/themadinventor/esptool


### PR DESCRIPTION
Python 3 is default on some systems, so this avoids that ambiguity.