### PR TITLE
Change shebang in order to run with correct python version

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # ESP8266 ROM Bootloader Utility
 # https://github.com/themadinventor/esptool


### PR DESCRIPTION
Some distribution ship with python3 as their default python implementation, which leads to esptool being run by python3, with which it is of course not compatible.