### PR TITLE
Fix for "Invalid response" message

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -100,11 +100,13 @@ class ESPROM:
             state ^= ord(b)
         return state
 
+    """ Send a request """
     def sendRequest(self, op, data, chk):
         # Construct and send request
         pkt = struct.pack('<BBHI', 0x00, op, len(data), chk) + data
         self.write(pkt)
 
+    """ Receive a response """
     def recvResponse(self):
         # Read header of response and parse
         if self._port.read(1) != '\xc0':
@@ -133,6 +135,10 @@ class ESPROM:
         if op:
             self.sendRequest(op, data, chk)
 
+        # tries to get a response until that response has the
+        # same operation as the request or a retries limit has
+        # exceeded. This is needed for some esp8266s that
+        # reply with more sync responses than expected.
         valid = False
         retries = 100
         while not valid and retries > 0:

--- a/esptool.py
+++ b/esptool.py
@@ -112,9 +112,6 @@ class ESPROM:
         if self._port.read(1) != '\xc0':
             raise Exception('Invalid head of packet')
         hdr = self.read(8)
-        hdr_hex = ":".join("{:02x}".format(ord(c)) for c in hdr)
-        print "response header: %s" % (hdr_hex)
-
         (resp, op_ret, len_ret, val) = struct.unpack('<BBHI', hdr)
 
         if resp != 0x01:
@@ -147,7 +144,6 @@ class ESPROM:
                 valid = True # responses without requests are always valid
             else:
                 valid = (op_ret == op)
-                print "op=%d op_ret=%d" % (op, op_ret)
             retries = retries - 1
 
         if not valid:


### PR DESCRIPTION
This PR solves the following error:

```
$ ./esptool.py -p /dev/ttyACM0 write_flash 0x00000 nodemcu.bin 
Connecting...
Erasing flash...
Traceback (most recent call last):
  File "./esptool.py", line 586, in <module>
    esp.flash_begin(blocks*esp.ESP_FLASH_BLOCK, address)
  File "./esptool.py", line 213, in flash_begin
    struct.pack('<IIII', erase_size, num_blocks, ESPROM.ESP_FLASH_BLOCK, offset))[1] != "\0\0":
  File "./esptool.py", line 116, in command
    raise Exception('Invalid response')
Exception: Invalid response
```

Turns out it was because the sync operations, made during the connection phase, made more replies than expected and the subsequent operation would fail.