### PR TITLE
Use bulk reads to massively reduce overheads.

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -77,17 +77,25 @@ class ESPROM:
     def read(self, length=1):
         b = ''
         while len(b) < length:
-            c = self._port.read(1)
-            if c == '\xdb':
-                c = self._port.read(1)
-                if c == '\xdc':
-                    b = b + '\xc0'
-                elif c == '\xdd':
-                    b = b + '\xdb'
+            d = self._port.read(length - len(b))
+            pos = 0
+            while pos < len(d):
+                c = d[pos]
+                pos = pos + 1
+                if c == '\xdb':
+                    if pos >= len(d):
+                        d = self._port.read(length - len(b))
+                        pos = 0
+                    c = d[pos]
+                    pos = pos + 1
+                    if c == '\xdc':
+                        b = b + '\xc0'
+                    elif c == '\xdd':
+                        b = b + '\xdb'
+                    else:
+                        raise FatalError('Invalid SLIP escape')
                 else:
-                    raise FatalError('Invalid SLIP escape')
-            else:
-                b = b + c
+                    b = b + c
         return b
 
     """ Write bytes to the serial port while performing SLIP escaping """


### PR DESCRIPTION
This patch makes it possible to verify large firmwares from a Raspberry Pi 2 too. Previously the overhead of reading a single byte at a time (going all the way into the kernel and back) made it impossible to verify at 230400 baud rate, and at 115200 it put a core at ~90%. With this patch, a verify at 230400 is both possible and only uses ~30% cpu.

Patch by @umisef (with white-space cleanup by yours truly).