### PR TITLE
Set python2 explicit

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # ESP8266 ROM Bootloader Utility
 # https://github.com/themadinventor/esptool


### PR DESCRIPTION
because distros are switching the default to python3 and a less eperienced user may fail to interpret the error-message.