### PR TITLE
Make sure python 2 is used

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # ESP8266 ROM Bootloader Utility
 # https://github.com/themadinventor/esptool


### PR DESCRIPTION
The script still uses python 2 syntax, more and more distros moved from python 2 to python 3 as standard python installation. Thus, they link python to python3. This makes it necessary to  explicit  call python2 for those distros.