### PR TITLE
Update esplool.py to use python2 not python3

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # NB: Before sending a PR to change the above line to '#!/usr/bin/env python2', please read https://github.com/themadinventor/esptool/issues/21
 #
 # ESP8266 ROM Bootloader Utility


### PR DESCRIPTION
After install something to my linux system default python2 changed to python3 and wen i try using esptool it give me grammatical error. Changing #!/usr/bin/env python to #!/usr/bin/env python2 solve problem :)