### PR TITLE
esptool: use serial_for_url instead of Serial

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -68,7 +68,7 @@ class ESPROM(object):
     ESP_FLASH_SECTOR = 0x1000
 
     def __init__(self, port=0, baud=ESP_ROM_BAUD):
-        self._port = serial.Serial(port)
+        self._port = serial.serial_for_url(port)
         self._slip_reader = slip_reader(self._port)
         # setting baud rate in a separate step is a workaround for
         # CH341 driver on some Linux versions (this opens at 9600 then


### PR DESCRIPTION
This change allows ports to be opened locally and remote (for example using RFC2217, but also other messaging protocols may be used).

see http://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.serial_for_url for details

It's useful if the compiling instance does not have direct serial port access to deploy the firmware (e.g. if you are within a docker container). 

serial_for_url is backward compatible to the existing Serial() call.